### PR TITLE
feat: landing page, app shell, and productivity features

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,0 +1,5 @@
+import AppShell from '@/components/app-shell';
+
+export default function AppPage() {
+  return <AppShell />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,10 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  font-family: Arial, Helvetica, sans-serif;
-}
-
 @layer utilities {
   .text-balance {
     text-wrap: balance;
@@ -89,6 +85,22 @@ body {
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-body;
   }
+}
+
+.font-display {
+  font-family: var(--font-display), ui-serif, Georgia, serif;
+}
+
+.font-body {
+  font-family: var(--font-body), ui-sans-serif, system-ui, sans-serif;
+}
+
+.landing-page {
+  font-family: var(--font-body), ui-sans-serif, system-ui, sans-serif;
+}
+
+.landing-page .font-display {
+  font-family: var(--font-display), ui-serif, Georgia, serif;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,26 @@
 import type React from 'react';
 import '@/app/globals.css';
-import { Inter } from 'next/font/google';
+import { Syne, DM_Sans } from 'next/font/google';
 import { Toaster } from '@/components/ui/toaster';
+import { ThemeProvider } from '@/components/theme-provider';
 import Script from 'next/script';
 
-const inter = Inter({ subsets: ['latin'] });
+const syne = Syne({
+  subsets: ['latin'],
+  variable: '--font-display',
+  display: 'swap',
+});
+
+const dmSans = DM_Sans({
+  subsets: ['latin'],
+  variable: '--font-body',
+  display: 'swap',
+});
 
 export const metadata = {
-  title: 'ChronoManager - Task Management App',
+  title: 'ChronoManager - Master Your Time, Command Your Tasks',
   description:
-    'An intuitive task management app featuring folders, lists, drag-and-drop, and three powerful views: Kanban, Priority, and List — designed to keep you organized and in control.',
+    'An intuitive task management app featuring folders, lists, drag-and-drop, and three powerful views: Kanban, Priority, and Checklist — designed to keep you organized and in control.',
   keywords: [
     'task management',
     'productivity',
@@ -52,7 +63,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang='en'>
+    <html lang='en' suppressHydrationWarning>
       <head>
         <link rel='icon' href='/favicon.svg' type='image/svg+xml' />
         <link
@@ -69,9 +80,16 @@ export default function RootLayout({
         />
         <link rel='apple-touch-icon' href='/icons/apple-touch-icon.svg' />
       </head>
-      <body className={inter.className}>
-        {children}
-        <Toaster />
+      <body className={`${syne.variable} ${dmSans.variable} font-body antialiased`}>
+        <ThemeProvider
+          attribute='class'
+          defaultTheme='light'
+          enableSystem
+          disableTransitionOnChange
+        >
+          {children}
+          <Toaster />
+        </ThemeProvider>
         <Script id='feeduser-widget' strategy='afterInteractive'>
           {`
             window.Fu = window.Fu || {};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,5 @@
-import FolderListSystem from '@/components/folder-list-system';
-import AppHeader from '@/components/app-header';
-import AnimatedBackground from '@/components/animated-background';
+import LandingPage from '@/components/landing/landing-page';
 
 export default function Home() {
-  return (
-    <>
-      <AnimatedBackground />
-      <AppHeader />
-      <main className='min-h-screen'>
-        <FolderListSystem />
-      </main>
-    </>
-  );
+  return <LandingPage />;
 }

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -3,17 +3,18 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { MoreHorizontal, Clock, Sparkles, Linkedin, Github } from 'lucide-react';
+import { Clock, Sparkles, Linkedin, Github } from 'lucide-react';
+import { ThemeToggle } from '@/components/theme-toggle';
 
 interface AppHeaderProps {
   className?: string;
+  children?: React.ReactNode;
 }
 
-export default function AppHeader({ className }: AppHeaderProps) {
+export default function AppHeader({ className, children }: AppHeaderProps) {
   const [scrolled, setScrolled] = useState(false);
   const [timeString, setTimeString] = useState('');
 
-  // Handle scroll effect
   useEffect(() => {
     const handleScroll = () => {
       setScrolled(window.scrollY > 10);
@@ -23,7 +24,6 @@ export default function AppHeader({ className }: AppHeaderProps) {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  // Update time
   useEffect(() => {
     const updateTime = () => {
       const now = new Date();
@@ -40,84 +40,66 @@ export default function AppHeader({ className }: AppHeaderProps) {
   return (
     <header
       className={cn(
-        'sticky top-0 z-30 transition-all duration-300 backdrop-blur-sm',
+        'sticky top-0 z-30 transition-all duration-300 backdrop-blur-sm border-b border-transparent',
         scrolled
-          ? 'shadow-md bg-white/80 dark:bg-black/80'
-          : 'bg-white/95 dark:bg-black/95',
+          ? 'shadow-md bg-white/80 dark:bg-zinc-950/80 border-border/50'
+          : 'bg-white/95 dark:bg-zinc-950/95',
         className
       )}
     >
-      <div className='flex items-center justify-between px-6 py-3'>
-        <Link href='/' className='group flex items-center space-x-2'>
-          <div className='relative h-10 w-10 transition-transform group-hover:rotate-12 duration-300'>
-            <div className='absolute inset-0 bg-gradient-to-br from-indigo-600 to-purple-600 rounded-lg transform rotate-3 group-hover:rotate-6 transition-transform duration-300 shadow-lg'></div>
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              viewBox='0 0 40 40'
-              className='h-10 w-10 relative z-10'
-              aria-hidden='true'
-            >
-              <rect width='40' height='40' rx='8' fill='#171717' />
-              <path
-                fill='#ffffff'
-                fillRule='evenodd'
-                d='M10 30l13-23l-3-2L5 30H10Z'
-                clipRule='evenodd'
-                className='animate-pulse'
-                style={{ animationDuration: '3s' }}
-              />
-              <path
-                fill='#ffffff'
-                fillRule='evenodd'
-                d='M16.5 30H31.5L21.5 16.5l-3 5.5l3 5.5H16.5L13.5 30Z'
-                clipRule='evenodd'
-              />
-            </svg>
+      <div className='flex items-center justify-between px-4 md:px-6 py-2.5 gap-4'>
+        <Link href='/app' className='group flex items-center space-x-2 shrink-0'>
+          <div className='relative h-9 w-9 transition-transform group-hover:rotate-12 duration-300'>
+            <div className='absolute inset-0 bg-gradient-to-br from-amber-400 to-teal-400 rounded-lg transform rotate-3 group-hover:rotate-6 transition-transform duration-300 shadow-lg opacity-80' />
+            <div className='absolute inset-0 rounded-lg bg-zinc-900 dark:bg-zinc-800 flex items-center justify-center'>
+              <Clock className='h-4 w-4 text-amber-400' />
+            </div>
           </div>
           <div className='flex flex-col'>
             <div className='flex items-center'>
-              <span className='text-xl font-bold leading-tight bg-clip-text text-transparent bg-gradient-to-r from-indigo-600 to-purple-600'>
-                ChronoManager
+              <span className='text-lg font-display font-bold leading-tight'>
+                Chrono<span className='text-amber-500'>Manager</span>
               </span>
-              <Sparkles className='h-4 w-4 ml-1 text-indigo-500 animate-pulse' />
+              <Sparkles className='h-3.5 w-3.5 ml-1 text-amber-400 animate-pulse' />
             </div>
-            <span className='text-xs text-muted-foreground leading-none'>
+            <span className='text-[10px] text-muted-foreground leading-none hidden sm:block'>
               Task Management
             </span>
           </div>
         </Link>
 
-        <div className='flex items-center gap-3'>
-          <div className='hidden md:flex items-center space-x-1 px-3 py-1.5 rounded-full bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200'>
-            <Clock className='h-4 w-4 mr-1 text-indigo-500' />
-            <span className='text-sm font-medium'>{timeString}</span>
+        <div className='flex items-center gap-1 md:gap-2 flex-1 justify-end'>
+          {children}
+
+          <div className='hidden md:flex items-center space-x-1 px-3 py-1.5 rounded-full bg-muted text-muted-foreground'>
+            <Clock className='h-3.5 w-3.5 mr-1 text-amber-500' />
+            <span className='text-sm font-medium tabular-nums'>{timeString}</span>
           </div>
 
-          <div className='flex items-center gap-4'>
+          <ThemeToggle />
+
+          <div className='flex items-center gap-3 ml-1'>
             <Link
               href='https://github.com/Abdelkaderbzz/taskly/tree/develop'
               target='_blank'
               rel='noopener noreferrer'
-              className='text-slate-600 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors'
+              className='text-muted-foreground hover:text-amber-500 transition-colors'
             >
-              <Github className='h-5 w-5' />
+              <Github className='h-4 w-4' />
               <span className='sr-only'>GitHub</span>
             </Link>
             <Link
               href='https://www.linkedin.com/in/bouzomita-abdelkader-928953234/'
               target='_blank'
               rel='noopener noreferrer'
-              className='text-slate-600 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors'
+              className='text-muted-foreground hover:text-amber-500 transition-colors'
             >
-              <Linkedin className='h-5 w-5' />
+              <Linkedin className='h-4 w-4' />
               <span className='sr-only'>LinkedIn</span>
             </Link>
           </div>
         </div>
       </div>
-
-      {/* Decorative element */}
-      <div className='absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500'></div>
     </header>
   );
 }

--- a/components/app-settings.tsx
+++ b/components/app-settings.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import {
+  Download,
+  Upload,
+  Settings,
+  Trash2,
+  BarChart3,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useToast } from '@/hooks/use-toast';
+import type { Folder } from '@/types/types';
+
+interface AppSettingsProps {
+  folders: Folder[];
+  onImport: (folders: Folder[]) => void;
+  onClearAll: () => void;
+}
+
+function getStats(folders: Folder[]) {
+  const totalLists = folders.reduce((acc, f) => acc + f.lists.length, 0);
+  const totalTasks = folders.reduce(
+    (acc, f) => acc + f.lists.reduce((a, l) => a + l.tasks.length, 0),
+    0
+  );
+  const completedTasks = folders.reduce(
+    (acc, f) =>
+      acc +
+      f.lists.reduce(
+        (a, l) =>
+          a +
+          l.tasks.filter(
+            (t) =>
+              t.status === 'done' ||
+              l.statuses.some(
+                (s) =>
+                  s.id === t.status && s.name.toLowerCase() === 'done'
+              )
+          ).length,
+        0
+      ),
+    0
+  );
+  const overdueTasks = folders.reduce(
+    (acc, f) =>
+      acc +
+      f.lists.reduce(
+        (a, l) =>
+          a +
+          l.tasks.filter(
+            (t) =>
+              t.dueDate &&
+              new Date(t.dueDate) < new Date() &&
+              t.status !== 'done'
+          ).length,
+        0
+      ),
+    0
+  );
+
+  return { totalLists, totalTasks, completedTasks, overdueTasks };
+}
+
+export function AppSettings({ folders, onImport, onClearAll }: AppSettingsProps) {
+  const { toast } = useToast();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const stats = getStats(folders);
+
+  const handleExport = () => {
+    const data = {
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      folders,
+    };
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `chronomanager-backup-${new Date().toISOString().split('T')[0]}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    toast({ title: 'Data exported', description: 'Your backup file has been downloaded.' });
+  };
+
+  const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const parsed = JSON.parse(event.target?.result as string);
+        const importedFolders: Folder[] = parsed.folders ?? parsed;
+        if (!Array.isArray(importedFolders)) throw new Error('Invalid format');
+        onImport(importedFolders);
+        toast({
+          title: 'Data imported',
+          description: `${importedFolders.length} folder(s) loaded successfully.`,
+        });
+      } catch {
+        toast({
+          title: 'Import failed',
+          description: 'Could not read the file. Make sure it is a valid ChronoManager backup.',
+          variant: 'destructive',
+        });
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  };
+
+  return (
+    <>
+      <Dialog>
+        <DialogTrigger asChild>
+          <Button variant='ghost' size='icon' className='h-9 w-9' aria-label='Settings'>
+            <Settings className='h-4 w-4' />
+          </Button>
+        </DialogTrigger>
+        <DialogContent className='sm:max-w-md'>
+          <DialogHeader>
+            <DialogTitle>Settings &amp; Data</DialogTitle>
+            <DialogDescription>
+              Manage your workspace data and view productivity stats.
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* Stats */}
+          <div className='grid grid-cols-2 gap-3 py-2'>
+            {[
+              { label: 'Folders', value: folders.length, icon: BarChart3 },
+              { label: 'Lists', value: stats.totalLists, icon: BarChart3 },
+              { label: 'Tasks', value: stats.totalTasks, icon: BarChart3 },
+              { label: 'Completed', value: stats.completedTasks, icon: BarChart3 },
+            ].map((item) => (
+              <div
+                key={item.label}
+                className='rounded-lg border bg-muted/40 p-3 text-center'
+              >
+                <div className='text-2xl font-bold'>{item.value}</div>
+                <div className='text-xs text-muted-foreground'>{item.label}</div>
+              </div>
+            ))}
+          </div>
+
+          {stats.overdueTasks > 0 && (
+            <p className='text-sm text-destructive text-center'>
+              {stats.overdueTasks} overdue task{stats.overdueTasks !== 1 ? 's' : ''}
+            </p>
+          )}
+
+          <div className='flex flex-col gap-2 pt-2'>
+            <Button variant='outline' className='justify-start gap-2' onClick={handleExport}>
+              <Download className='h-4 w-4' />
+              Export backup (JSON)
+            </Button>
+            <Button
+              variant='outline'
+              className='justify-start gap-2'
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Upload className='h-4 w-4' />
+              Import backup
+            </Button>
+            <input
+              ref={fileInputRef}
+              type='file'
+              accept='.json'
+              className='hidden'
+              onChange={handleImport}
+            />
+            <Button
+              variant='outline'
+              className='justify-start gap-2 text-destructive hover:text-destructive'
+              onClick={() => setShowClearConfirm(true)}
+            >
+              <Trash2 className='h-4 w-4' />
+              Clear all data
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={showClearConfirm} onOpenChange={setShowClearConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clear all data?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete all folders, lists, and tasks. Export
+              a backup first if you want to keep your data.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
+              onClick={() => {
+                onClearAll();
+                setShowClearConfirm(false);
+                toast({ title: 'All data cleared', description: 'Your workspace has been reset.' });
+              }}
+            >
+              Clear everything
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import FolderListSystem from '@/components/folder-list-system';
+import AppHeader from '@/components/app-header';
+import AnimatedBackground from '@/components/animated-background';
+import { GlobalSearch } from '@/components/global-search';
+import { AppSettings } from '@/components/app-settings';
+import type { Folder } from '@/types/types';
+
+export default function AppShell() {
+  const [folders, setFolders] = useState<Folder[]>([]);
+  const [navTarget, setNavTarget] = useState<{
+    folderId: string;
+    listId: string;
+    taskId?: string;
+  } | null>(null);
+
+  const handleFoldersChange = useCallback((updated: Folder[]) => {
+    setFolders(updated);
+  }, []);
+
+  const handleSelectTask = useCallback(
+    (folderId: string, listId: string, _taskId: string) => {
+      setNavTarget({ folderId, listId, taskId: _taskId });
+    },
+    []
+  );
+
+  const handleSelectList = useCallback((folderId: string, listId: string) => {
+    setNavTarget({ folderId, listId });
+  }, []);
+
+  const handleImport = useCallback((imported: Folder[]) => {
+    localStorage.setItem('folders', JSON.stringify(imported));
+    if (imported[0]) {
+      localStorage.setItem('activeFolder', imported[0].id);
+      if (imported[0].lists[0]) {
+        localStorage.setItem('activeList', imported[0].lists[0].id);
+      }
+    }
+    window.location.reload();
+  }, []);
+
+  const handleClearAll = useCallback(() => {
+    localStorage.removeItem('folders');
+    localStorage.removeItem('activeFolder');
+    localStorage.removeItem('activeList');
+    window.location.reload();
+  }, []);
+
+  return (
+    <>
+      <AnimatedBackground />
+      <AppHeader>
+        <GlobalSearch
+          folders={folders}
+          onSelectTask={handleSelectTask}
+          onSelectList={handleSelectList}
+        />
+        <AppSettings
+          folders={folders}
+          onImport={handleImport}
+          onClearAll={handleClearAll}
+        />
+      </AppHeader>
+      <main className='min-h-[calc(100vh-57px)]'>
+        <FolderListSystem
+          onFoldersChange={handleFoldersChange}
+          navTarget={navTarget}
+          onNavTargetHandled={() => setNavTarget(null)}
+        />
+      </main>
+    </>
+  );
+}

--- a/components/folder-list-system.tsx
+++ b/components/folder-list-system.tsx
@@ -5,11 +5,20 @@ import { v4 as uuidv4 } from 'uuid';
 import { useToast } from '@/hooks/use-toast';
 import EnhancedSidebar from '@/components/enhanced-sidebar';
 import MainContent from '@/components/main-content';
-import AnimatedBackground from '@/components/animated-background';
 import confetti from 'canvas-confetti';
 import type { Folder, List, Task, ViewType, Status } from '@/types/types';
 
-export default function FolderListSystem() {
+interface FolderListSystemProps {
+  onFoldersChange?: (folders: Folder[]) => void;
+  navTarget?: { folderId: string; listId: string; taskId?: string } | null;
+  onNavTargetHandled?: () => void;
+}
+
+export default function FolderListSystem({
+  onFoldersChange,
+  navTarget,
+  onNavTargetHandled,
+}: FolderListSystemProps = {}) {
   const { toast } = useToast();
   const [folders, setFolders] = useState<Folder[]>([]);
   const [activeFolder, setActiveFolder] = useState<string | null>(null);
@@ -206,6 +215,16 @@ export default function FolderListSystem() {
     }
   }, []);
 
+  // Handle navigation from global search
+  useEffect(() => {
+    if (navTarget) {
+      setActiveFolder(navTarget.folderId);
+      setActiveList(navTarget.listId);
+      setIsMobileMenuOpen(false);
+      onNavTargetHandled?.();
+    }
+  }, [navTarget, onNavTargetHandled]);
+
   // Save data to localStorage whenever it changes
   useEffect(() => {
     if (folders.length > 0) {
@@ -220,6 +239,13 @@ export default function FolderListSystem() {
       localStorage.setItem('activeList', activeList);
     }
   }, [folders, activeFolder, activeList]);
+
+  // Notify parent of folder changes for search/settings
+  useEffect(() => {
+    if (folders.length > 0) {
+      onFoldersChange?.(folders);
+    }
+  }, [folders, onFoldersChange]);
 
   const handleCreateFolder = (newFolder: Omit<Folder, 'id' | 'lists'>) => {
     const folder: Folder = {
@@ -763,8 +789,7 @@ export default function FolderListSystem() {
   };
 
   return (
-    <div className='flex h-screen overflow-hidden'>
-      <AnimatedBackground />
+    <div className='flex h-[calc(100vh-57px)] overflow-hidden'>
 
       <EnhancedSidebar
         folders={folders}

--- a/components/global-search.tsx
+++ b/components/global-search.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Calendar,
+  CheckSquare,
+  FolderOpen,
+  Search,
+} from 'lucide-react';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command';
+import { Button } from '@/components/ui/button';
+import type { Folder } from '@/types/types';
+import { format } from 'date-fns';
+
+interface GlobalSearchProps {
+  folders: Folder[];
+  onSelectTask: (folderId: string, listId: string, taskId: string) => void;
+  onSelectList: (folderId: string, listId: string) => void;
+}
+
+export function GlobalSearch({
+  folders,
+  onSelectTask,
+  onSelectList,
+}: GlobalSearchProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    };
+    document.addEventListener('keydown', down);
+    return () => document.removeEventListener('keydown', down);
+  }, []);
+
+  const handleSelectTask = useCallback(
+    (folderId: string, listId: string, taskId: string) => {
+      onSelectTask(folderId, listId, taskId);
+      setOpen(false);
+    },
+    [onSelectTask]
+  );
+
+  const handleSelectList = useCallback(
+    (folderId: string, listId: string) => {
+      onSelectList(folderId, listId);
+      setOpen(false);
+    },
+    [onSelectList]
+  );
+
+  const allTasks = folders.flatMap((folder) =>
+    folder.lists.flatMap((list) =>
+      list.tasks.map((task) => ({ folder, list, task }))
+    )
+  );
+
+  const allLists = folders.flatMap((folder) =>
+    folder.lists.map((list) => ({ folder, list }))
+  );
+
+  return (
+    <>
+      <Button
+        variant='outline'
+        className='hidden md:flex items-center gap-2 h-9 px-3 text-muted-foreground border-dashed'
+        onClick={() => setOpen(true)}
+      >
+        <Search className='h-4 w-4' />
+        <span className='text-sm'>Search tasks...</span>
+        <kbd className='pointer-events-none ml-2 hidden lg:inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground'>
+          <span className='text-xs'>⌘</span>K
+        </kbd>
+      </Button>
+
+      <Button
+        variant='ghost'
+        size='icon'
+        className='md:hidden h-9 w-9'
+        onClick={() => setOpen(true)}
+        aria-label='Search'
+      >
+        <Search className='h-4 w-4' />
+      </Button>
+
+      <CommandDialog open={open} onOpenChange={setOpen}>
+        <CommandInput placeholder='Search tasks, lists, folders...' />
+        <CommandList>
+          <CommandEmpty>No results found.</CommandEmpty>
+
+          {allTasks.length > 0 && (
+            <CommandGroup heading='Tasks'>
+              {allTasks.map(({ folder, list, task }) => (
+                <CommandItem
+                  key={task.id}
+                  value={`${task.title} ${task.description} ${folder.name} ${list.name}`}
+                  onSelect={() => handleSelectTask(folder.id, list.id, task.id)}
+                >
+                  <CheckSquare className='mr-2 h-4 w-4 text-muted-foreground' />
+                  <div className='flex flex-col flex-1 min-w-0'>
+                    <span className='truncate'>{task.title}</span>
+                    <span className='text-xs text-muted-foreground truncate'>
+                      {folder.name} / {list.name}
+                    </span>
+                  </div>
+                  {task.dueDate && (
+                    <span className='ml-2 text-xs text-muted-foreground flex items-center gap-1 shrink-0'>
+                      <Calendar className='h-3 w-3' />
+                      {format(new Date(task.dueDate), 'MMM d')}
+                    </span>
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+
+          {allLists.length > 0 && (
+            <>
+              <CommandSeparator />
+              <CommandGroup heading='Lists'>
+                {allLists.map(({ folder, list }) => (
+                  <CommandItem
+                    key={list.id}
+                    value={`${list.name} ${folder.name} ${list.tags.join(' ')}`}
+                    onSelect={() => handleSelectList(folder.id, list.id)}
+                  >
+                    <FolderOpen className='mr-2 h-4 w-4 text-muted-foreground' />
+                    <div className='flex flex-col'>
+                      <span>{list.name}</span>
+                      <span className='text-xs text-muted-foreground'>
+                        {folder.name}
+                      </span>
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </>
+          )}
+        </CommandList>
+      </CommandDialog>
+    </>
+  );
+}

--- a/components/landing/landing-page.tsx
+++ b/components/landing/landing-page.tsx
@@ -17,70 +17,150 @@ import {
 import { Button } from '@/components/ui/button';
 
 function LiveClock() {
-  const [time, setTime] = useState('');
-  const [date, setDate] = useState('');
+  const [now, setNow] = useState<Date | null>(null);
 
   useEffect(() => {
-    const tick = () => {
-      const now = new Date();
-      setTime(
-        now.toLocaleTimeString([], {
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit',
-        })
-      );
-      setDate(
-        now.toLocaleDateString([], {
-          weekday: 'long',
-          month: 'long',
-          day: 'numeric',
-        })
-      );
-    };
-    tick();
-    const id = setInterval(tick, 1000);
+    setNow(new Date());
+    const id = setInterval(() => setNow(new Date()), 1000);
     return () => clearInterval(id);
   }, []);
 
-  return (
-    <div className='font-mono text-right'>
-      <div className='text-3xl md:text-4xl font-light tracking-widest text-amber-400 tabular-nums'>
-        {time}
+  if (!now) {
+    return (
+      <div className='flex flex-col items-center justify-center gap-1 min-h-[72px]'>
+        <div className='h-8 w-28 rounded bg-zinc-800/60 animate-pulse' />
+        <div className='h-3 w-36 rounded bg-zinc-800/40 animate-pulse' />
       </div>
-      <div className='text-xs text-zinc-500 mt-1 tracking-wide uppercase'>
-        {date}
+    );
+  }
+
+  const hours = now.getHours() % 12;
+  const minutes = now.getMinutes();
+  const seconds = now.getSeconds();
+
+  const secondAngle = seconds * 6;
+  const minuteAngle = minutes * 6 + seconds * 0.1;
+  const hourAngle = hours * 30 + minutes * 0.5;
+
+  const timeLabel = now.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  const dateLabel = now.toLocaleDateString([], {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  return (
+    <div className='flex flex-col items-center gap-5'>
+      {/* Analog clock */}
+      <div className='relative w-52 h-52 md:w-56 md:h-56'>
+        <div className='absolute inset-0 rounded-full bg-[#12121a] border border-zinc-700/80 shadow-2xl shadow-amber-400/10'>
+          <div className='absolute inset-0 rounded-full bg-gradient-to-br from-amber-400/8 via-transparent to-teal-400/5' />
+
+          {/* Hour markers */}
+          {Array.from({ length: 12 }).map((_, i) => (
+            <div
+              key={i}
+              className='absolute left-1/2 top-1/2 h-[88px] w-0 origin-bottom'
+              style={{ transform: `rotate(${i * 30}deg)` }}
+            >
+              <div
+                className={`mx-auto rounded-full ${i % 3 === 0 ? 'w-1.5 h-1.5 bg-amber-400/80' : 'w-1 h-1 bg-zinc-600'}`}
+              />
+            </div>
+          ))}
+
+          {/* Clock hands */}
+          <div className='absolute inset-0 flex items-center justify-center'>
+            <div
+              className='absolute w-1 h-14 md:h-16 bg-amber-400/90 origin-bottom bottom-1/2 rounded-full shadow-sm'
+              style={{ transform: `rotate(${hourAngle}deg)` }}
+            />
+            <div
+              className='absolute w-0.5 h-[4.5rem] md:h-20 bg-teal-400/80 origin-bottom bottom-1/2 rounded-full'
+              style={{ transform: `rotate(${minuteAngle}deg)` }}
+            />
+            <div
+              className='absolute w-px h-[4.5rem] md:h-20 bg-red-400/70 origin-bottom bottom-1/2 rounded-full'
+              style={{ transform: `rotate(${secondAngle}deg)` }}
+            />
+            <div className='absolute w-3 h-3 rounded-full bg-amber-400 border-2 border-[#12121a] z-10' />
+          </div>
+        </div>
+
+        {/* Orbit rings — static, clearer contrast */}
+        <div className='absolute -inset-6 rounded-full border border-dashed border-amber-400/25 pointer-events-none' />
+        <div className='absolute -inset-12 rounded-full border border-dashed border-teal-400/20 pointer-events-none' />
+      </div>
+
+      {/* Digital readout — outside the dial so nothing clips */}
+      <div className='text-center space-y-1'>
+        <div className='font-mono text-2xl md:text-3xl font-medium text-amber-400 tabular-nums tracking-wide'>
+          {timeLabel}
+        </div>
+        <div className='text-xs text-zinc-500 tracking-widest uppercase'>
+          {dateLabel}
+        </div>
       </div>
     </div>
   );
 }
 
-function OrbitRing({
-  size,
-  duration,
+function OrbitTask({
+  label,
+  angle,
+  radius,
   delay,
-  color,
 }: {
-  size: number;
-  duration: number;
+  label: string;
+  angle: number;
+  radius: number;
   delay: number;
-  color: string;
 }) {
+  const rad = (angle * Math.PI) / 180;
+  const x = Math.cos(rad) * radius;
+  const y = Math.sin(rad) * radius;
+
   return (
-    <motion.div
-      className='absolute rounded-full border border-dashed opacity-30'
-      style={{
-        width: size,
-        height: size,
-        borderColor: color,
-        left: '50%',
-        top: '50%',
-        marginLeft: -size / 2,
-        marginTop: -size / 2,
-      }}
-      animate={{ rotate: 360 }}
-      transition={{ duration, repeat: Infinity, ease: 'linear', delay }}
-    />
+    <div
+      className='absolute left-1/2 top-[42%] z-20'
+      style={{ transform: `translate(calc(-50% + ${x}px), calc(-50% + ${y}px))` }}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.85 }}
+        animate={{ opacity: 1, scale: 1, y: [0, -5, 0] }}
+        transition={{
+          opacity: { delay, duration: 0.4 },
+          scale: { delay, duration: 0.4 },
+          y: { delay: delay + 0.5, duration: 3, repeat: Infinity, ease: 'easeInOut' },
+        }}
+        className='px-3 py-2 rounded-xl bg-[#12121a]/95 border border-zinc-700/80 text-xs text-zinc-200 backdrop-blur-md shadow-xl whitespace-nowrap'
+      >
+        <div className='flex items-center gap-2'>
+          <div className='w-2 h-2 rounded-full bg-teal-400 shrink-0' />
+          {label}
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+function HeroClockVisual() {
+  return (
+    <div className='relative flex items-center justify-center w-full max-w-[420px] mx-auto aspect-square'>
+      {/* Soft glow behind */}
+      <div className='absolute inset-8 rounded-full bg-amber-400/5 blur-3xl' />
+
+      {/* Task cards — placed on outer ring, away from the dial */}
+      <OrbitTask label='Design review' angle={-130} radius={168} delay={0.3} />
+      <OrbitTask label='Ship feature' angle={-20} radius={175} delay={0.5} />
+      <OrbitTask label='Team sync' angle={170} radius={168} delay={0.7} />
+
+      <LiveClock />
+    </div>
   );
 }
 
@@ -261,54 +341,9 @@ export default function LandingPage() {
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.8, delay: 0.2, ease: [0.22, 1, 0.36, 1] }}
-            className='relative flex items-center justify-center h-[400px] lg:h-[480px]'
+            className='relative flex items-center justify-center min-h-[420px] lg:min-h-[480px]'
           >
-            <div className='relative w-72 h-72 md:w-80 md:h-80'>
-              <OrbitRing size={320} duration={60} delay={0} color='#f5a623' />
-              <OrbitRing size={260} duration={45} delay={5} color='#00d4aa' />
-              <OrbitRing size={200} duration={30} delay={2} color='#7c6af7' />
-
-              {/* Center clock face */}
-              <div className='absolute inset-0 flex items-center justify-center'>
-                <div className='w-36 h-36 md:w-44 md:h-44 rounded-full bg-[#12121a] border border-zinc-800 shadow-2xl shadow-amber-400/10 flex flex-col items-center justify-center relative overflow-hidden'>
-                  <div className='absolute inset-0 bg-gradient-to-br from-amber-400/5 to-transparent' />
-                  <LiveClock />
-
-                  {/* Clock hands decoration */}
-                  <motion.div
-                    className='absolute w-0.5 h-12 bg-amber-400/60 origin-bottom bottom-1/2 rounded-full'
-                    animate={{ rotate: 360 }}
-                    transition={{ duration: 60, repeat: Infinity, ease: 'linear' }}
-                  />
-                  <motion.div
-                    className='absolute w-0.5 h-8 bg-teal-400/60 origin-bottom bottom-1/2 rounded-full'
-                    animate={{ rotate: 360 }}
-                    transition={{ duration: 3600, repeat: Infinity, ease: 'linear' }}
-                  />
-                </div>
-              </div>
-
-              {/* Floating task cards */}
-              {[
-                { label: 'Design review', x: -120, y: -60, delay: 0.4 },
-                { label: 'Ship feature', x: 100, y: -80, delay: 0.6 },
-                { label: 'Team sync', x: -100, y: 80, delay: 0.8 },
-              ].map((card) => (
-                <motion.div
-                  key={card.label}
-                  initial={{ opacity: 0, scale: 0.8 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ delay: card.delay, duration: 0.5 }}
-                  className='absolute px-3 py-2 rounded-lg bg-[#12121a]/90 border border-zinc-800 text-xs text-zinc-300 backdrop-blur-sm shadow-lg'
-                  style={{ left: `calc(50% + ${card.x}px)`, top: `calc(50% + ${card.y}px)` }}
-                >
-                  <div className='flex items-center gap-2'>
-                    <div className='w-2 h-2 rounded-full bg-teal-400' />
-                    {card.label}
-                  </div>
-                </motion.div>
-              ))}
-            </div>
+            <HeroClockVisual />
           </motion.div>
         </div>
       </section>
@@ -488,6 +523,14 @@ export default function LandingPage() {
             <Link href='/app' className='hover:text-amber-400 transition-colors'>
               Open App
             </Link>
+            <a
+              href='https://abdelkader.work'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='hover:text-amber-400 transition-colors'
+            >
+              abdelkader.work
+            </a>
             <a
               href='https://github.com/Abdelkaderbzz/taskly/tree/develop'
               target='_blank'

--- a/components/landing/landing-page.tsx
+++ b/components/landing/landing-page.tsx
@@ -1,0 +1,504 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import {
+  ArrowRight,
+  BarChart3,
+  CheckSquare,
+  Clock,
+  FolderOpen,
+  Kanban,
+  Moon,
+  Sparkles,
+  Zap,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+function LiveClock() {
+  const [time, setTime] = useState('');
+  const [date, setDate] = useState('');
+
+  useEffect(() => {
+    const tick = () => {
+      const now = new Date();
+      setTime(
+        now.toLocaleTimeString([], {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        })
+      );
+      setDate(
+        now.toLocaleDateString([], {
+          weekday: 'long',
+          month: 'long',
+          day: 'numeric',
+        })
+      );
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className='font-mono text-right'>
+      <div className='text-3xl md:text-4xl font-light tracking-widest text-amber-400 tabular-nums'>
+        {time}
+      </div>
+      <div className='text-xs text-zinc-500 mt-1 tracking-wide uppercase'>
+        {date}
+      </div>
+    </div>
+  );
+}
+
+function OrbitRing({
+  size,
+  duration,
+  delay,
+  color,
+}: {
+  size: number;
+  duration: number;
+  delay: number;
+  color: string;
+}) {
+  return (
+    <motion.div
+      className='absolute rounded-full border border-dashed opacity-30'
+      style={{
+        width: size,
+        height: size,
+        borderColor: color,
+        left: '50%',
+        top: '50%',
+        marginLeft: -size / 2,
+        marginTop: -size / 2,
+      }}
+      animate={{ rotate: 360 }}
+      transition={{ duration, repeat: Infinity, ease: 'linear', delay }}
+    />
+  );
+}
+
+const features = [
+  {
+    icon: Kanban,
+    title: 'Kanban Boards',
+    description:
+      'Drag tasks across custom columns. Build workflows that match how you actually work.',
+    accent: '#00d4aa',
+  },
+  {
+    icon: BarChart3,
+    title: 'Priority Matrix',
+    description:
+      'See urgency at a glance. Sort and filter by priority to focus on what matters most.',
+    accent: '#f5a623',
+  },
+  {
+    icon: CheckSquare,
+    title: 'Checklist View',
+    description:
+      'Simple, satisfying check-offs for errands, shopping lists, and quick wins.',
+    accent: '#7c6af7',
+  },
+  {
+    icon: FolderOpen,
+    title: 'Folder Hierarchy',
+    description:
+      'Organize projects into folders and lists. Favorites keep your go-tos one click away.',
+    accent: '#ff6b6b',
+  },
+  {
+    icon: Moon,
+    title: 'Dark Mode',
+    description:
+      'Easy on the eyes, day or night. Toggle themes without losing your flow.',
+    accent: '#a78bfa',
+  },
+  {
+    icon: Zap,
+    title: 'Instant Search',
+    description:
+      'Press ⌘K to find any task across all folders. No more hunting through lists.',
+    accent: '#34d399',
+  },
+];
+
+const stats = [
+  { value: '3', label: 'Powerful views' },
+  { value: '∞', label: 'Folders & lists' },
+  { value: '0ms', label: 'Cloud latency' },
+  { value: '100%', label: 'Your data, local' },
+];
+
+export default function LandingPage() {
+  return (
+    <div className='landing-page min-h-screen bg-[#080810] text-[#f0ede6] overflow-x-hidden'>
+      {/* Grain overlay */}
+      <div
+        className='fixed inset-0 pointer-events-none z-50 opacity-[0.035]'
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E")`,
+        }}
+      />
+
+      {/* Ambient glow */}
+      <div className='fixed top-0 left-1/2 -translate-x-1/2 w-[800px] h-[400px] bg-amber-500/5 blur-[120px] pointer-events-none' />
+      <div className='fixed bottom-0 right-0 w-[600px] h-[400px] bg-teal-500/5 blur-[100px] pointer-events-none' />
+
+      {/* Navigation */}
+      <nav className='relative z-10 flex items-center justify-between px-6 md:px-12 py-6 max-w-7xl mx-auto'>
+        <Link href='/' className='flex items-center gap-3 group'>
+          <div className='relative w-9 h-9'>
+            <div className='absolute inset-0 rounded-lg bg-amber-400/20 rotate-6 group-hover:rotate-12 transition-transform duration-300' />
+            <div className='relative w-9 h-9 rounded-lg bg-[#12121a] border border-amber-400/30 flex items-center justify-center'>
+              <Clock className='w-4 h-4 text-amber-400' />
+            </div>
+          </div>
+          <span className='font-display text-lg font-bold tracking-tight'>
+            Chrono<span className='text-amber-400'>Manager</span>
+          </span>
+        </Link>
+
+        <div className='hidden md:flex items-center gap-8 text-sm text-zinc-400'>
+          <a href='#features' className='hover:text-amber-400 transition-colors'>
+            Features
+          </a>
+          <a href='#how-it-works' className='hover:text-amber-400 transition-colors'>
+            How it works
+          </a>
+        </div>
+
+        <div className='flex items-center gap-3'>
+          <Link href='/app'>
+            <Button
+              variant='ghost'
+              className='text-zinc-400 hover:text-amber-400 hover:bg-amber-400/10 hidden sm:flex'
+            >
+              Open App
+            </Button>
+          </Link>
+          <Link href='/app'>
+            <Button className='bg-amber-400 text-[#080810] hover:bg-amber-300 font-semibold rounded-full px-5'>
+              Get Started
+              <ArrowRight className='w-4 h-4 ml-1' />
+            </Button>
+          </Link>
+        </div>
+      </nav>
+
+      {/* Hero */}
+      <section className='relative z-10 px-6 md:px-12 pt-12 pb-24 max-w-7xl mx-auto'>
+        <div className='grid lg:grid-cols-2 gap-12 lg:gap-8 items-center'>
+          <motion.div
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, ease: [0.22, 1, 0.36, 1] }}
+          >
+            <div className='inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-amber-400/20 bg-amber-400/5 text-amber-400 text-xs font-medium mb-8'>
+              <Sparkles className='w-3 h-3' />
+              Free &amp; open source task management
+            </div>
+
+            <h1 className='font-display text-5xl md:text-6xl lg:text-7xl font-bold leading-[1.05] tracking-tight mb-6'>
+              Master your{' '}
+              <span className='relative inline-block'>
+                <span className='text-amber-400'>time</span>
+                <svg
+                  className='absolute -bottom-1 left-0 w-full'
+                  height='8'
+                  viewBox='0 0 200 8'
+                  fill='none'
+                >
+                  <path
+                    d='M1 5.5C40 1.5 80 1.5 120 5.5C160 9.5 180 3.5 199 5.5'
+                    stroke='#f5a623'
+                    strokeWidth='2'
+                    strokeLinecap='round'
+                    opacity='0.6'
+                  />
+                </svg>
+              </span>
+              ,<br />
+              command your tasks.
+            </h1>
+
+            <p className='text-lg text-zinc-400 leading-relaxed max-w-lg mb-10'>
+              ChronoManager turns scattered to-dos into organized momentum.
+              Folders, kanban boards, and priority views — all stored locally,
+              always under your control.
+            </p>
+
+            <div className='flex flex-wrap items-center gap-4'>
+              <Link href='/app'>
+                <Button
+                  size='lg'
+                  className='bg-amber-400 text-[#080810] hover:bg-amber-300 font-semibold rounded-full px-8 h-12 text-base'
+                >
+                  Start organizing
+                  <ArrowRight className='w-4 h-4 ml-2' />
+                </Button>
+              </Link>
+              <a href='#features'>
+                <Button
+                  size='lg'
+                  variant='outline'
+                  className='border-zinc-700 text-zinc-300 hover:bg-zinc-800/50 hover:text-amber-400 rounded-full px-8 h-12 text-base'
+                >
+                  Explore features
+                </Button>
+              </a>
+            </div>
+          </motion.div>
+
+          {/* Clock visual */}
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.8, delay: 0.2, ease: [0.22, 1, 0.36, 1] }}
+            className='relative flex items-center justify-center h-[400px] lg:h-[480px]'
+          >
+            <div className='relative w-72 h-72 md:w-80 md:h-80'>
+              <OrbitRing size={320} duration={60} delay={0} color='#f5a623' />
+              <OrbitRing size={260} duration={45} delay={5} color='#00d4aa' />
+              <OrbitRing size={200} duration={30} delay={2} color='#7c6af7' />
+
+              {/* Center clock face */}
+              <div className='absolute inset-0 flex items-center justify-center'>
+                <div className='w-36 h-36 md:w-44 md:h-44 rounded-full bg-[#12121a] border border-zinc-800 shadow-2xl shadow-amber-400/10 flex flex-col items-center justify-center relative overflow-hidden'>
+                  <div className='absolute inset-0 bg-gradient-to-br from-amber-400/5 to-transparent' />
+                  <LiveClock />
+
+                  {/* Clock hands decoration */}
+                  <motion.div
+                    className='absolute w-0.5 h-12 bg-amber-400/60 origin-bottom bottom-1/2 rounded-full'
+                    animate={{ rotate: 360 }}
+                    transition={{ duration: 60, repeat: Infinity, ease: 'linear' }}
+                  />
+                  <motion.div
+                    className='absolute w-0.5 h-8 bg-teal-400/60 origin-bottom bottom-1/2 rounded-full'
+                    animate={{ rotate: 360 }}
+                    transition={{ duration: 3600, repeat: Infinity, ease: 'linear' }}
+                  />
+                </div>
+              </div>
+
+              {/* Floating task cards */}
+              {[
+                { label: 'Design review', x: -120, y: -60, delay: 0.4 },
+                { label: 'Ship feature', x: 100, y: -80, delay: 0.6 },
+                { label: 'Team sync', x: -100, y: 80, delay: 0.8 },
+              ].map((card) => (
+                <motion.div
+                  key={card.label}
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ delay: card.delay, duration: 0.5 }}
+                  className='absolute px-3 py-2 rounded-lg bg-[#12121a]/90 border border-zinc-800 text-xs text-zinc-300 backdrop-blur-sm shadow-lg'
+                  style={{ left: `calc(50% + ${card.x}px)`, top: `calc(50% + ${card.y}px)` }}
+                >
+                  <div className='flex items-center gap-2'>
+                    <div className='w-2 h-2 rounded-full bg-teal-400' />
+                    {card.label}
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Stats bar */}
+      <section className='relative z-10 border-y border-zinc-800/60 bg-[#0c0c14]/80 backdrop-blur-sm'>
+        <div className='max-w-7xl mx-auto px-6 md:px-12 py-10 grid grid-cols-2 md:grid-cols-4 gap-8'>
+          {stats.map((stat, i) => (
+            <motion.div
+              key={stat.label}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+              className='text-center'
+            >
+              <div className='font-display text-3xl md:text-4xl font-bold text-amber-400 mb-1'>
+                {stat.value}
+              </div>
+              <div className='text-sm text-zinc-500'>{stat.label}</div>
+            </motion.div>
+          ))}
+        </div>
+      </section>
+
+      {/* Features */}
+      <section id='features' className='relative z-10 px-6 md:px-12 py-24 max-w-7xl mx-auto'>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          className='text-center mb-16'
+        >
+          <h2 className='font-display text-3xl md:text-5xl font-bold mb-4'>
+            Everything you need,{' '}
+            <span className='text-teal-400'>nothing you don&apos;t</span>
+          </h2>
+          <p className='text-zinc-400 max-w-xl mx-auto'>
+            Built for people who want powerful organization without the bloat of
+            enterprise tools.
+          </p>
+        </motion.div>
+
+        <div className='grid md:grid-cols-2 lg:grid-cols-3 gap-5'>
+          {features.map((feature, i) => (
+            <motion.div
+              key={feature.title}
+              initial={{ opacity: 0, y: 24 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.08 }}
+              className='group relative p-6 rounded-2xl bg-[#0c0c14] border border-zinc-800/80 hover:border-zinc-700 transition-all duration-300 hover:-translate-y-1'
+            >
+              <div
+                className='w-10 h-10 rounded-xl flex items-center justify-center mb-4 transition-transform group-hover:scale-110'
+                style={{ backgroundColor: `${feature.accent}15` }}
+              >
+                <feature.icon
+                  className='w-5 h-5'
+                  style={{ color: feature.accent }}
+                />
+              </div>
+              <h3 className='font-display text-lg font-semibold mb-2'>
+                {feature.title}
+              </h3>
+              <p className='text-sm text-zinc-400 leading-relaxed'>
+                {feature.description}
+              </p>
+            </motion.div>
+          ))}
+        </div>
+      </section>
+
+      {/* How it works */}
+      <section
+        id='how-it-works'
+        className='relative z-10 px-6 md:px-12 py-24 bg-[#0c0c14]/50 border-y border-zinc-800/60'
+      >
+        <div className='max-w-7xl mx-auto'>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className='text-center mb-16'
+          >
+            <h2 className='font-display text-3xl md:text-5xl font-bold mb-4'>
+              Up and running in{' '}
+              <span className='text-amber-400'>seconds</span>
+            </h2>
+          </motion.div>
+
+          <div className='grid md:grid-cols-3 gap-8 md:gap-12'>
+            {[
+              {
+                step: '01',
+                title: 'Create folders',
+                desc: 'Group your projects — Work, Personal, Side Projects — each with its own color and icon.',
+              },
+              {
+                step: '02',
+                title: 'Add lists & tasks',
+                desc: 'Break folders into focused lists. Add tasks with priorities, due dates, and descriptions.',
+              },
+              {
+                step: '03',
+                title: 'Pick your view',
+                desc: 'Switch between Kanban, Checklist, or Priority table — per list, on the fly.',
+              },
+            ].map((item, i) => (
+              <motion.div
+                key={item.step}
+                initial={{ opacity: 0, x: -20 }}
+                whileInView={{ opacity: 1, x: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: i * 0.15 }}
+                className='relative'
+              >
+                <div className='font-display text-6xl font-bold text-zinc-800 mb-4'>
+                  {item.step}
+                </div>
+                <h3 className='font-display text-xl font-semibold mb-2'>
+                  {item.title}
+                </h3>
+                <p className='text-zinc-400 text-sm leading-relaxed'>
+                  {item.desc}
+                </p>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className='relative z-10 px-6 md:px-12 py-24 max-w-7xl mx-auto text-center'>
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          whileInView={{ opacity: 1, scale: 1 }}
+          viewport={{ once: true }}
+          className='relative rounded-3xl overflow-hidden p-12 md:p-16'
+        >
+          <div className='absolute inset-0 bg-gradient-to-br from-amber-400/10 via-transparent to-teal-400/10' />
+          <div className='absolute inset-0 border border-zinc-800 rounded-3xl' />
+
+          <div className='relative'>
+            <h2 className='font-display text-3xl md:text-5xl font-bold mb-4'>
+              Your time is finite.
+              <br />
+              <span className='text-amber-400'>Make it count.</span>
+            </h2>
+            <p className='text-zinc-400 mb-8 max-w-md mx-auto'>
+              No sign-up. No subscription. Just open the app and start
+              organizing.
+            </p>
+            <Link href='/app'>
+              <Button
+                size='lg'
+                className='bg-amber-400 text-[#080810] hover:bg-amber-300 font-semibold rounded-full px-10 h-14 text-base'
+              >
+                Launch ChronoManager
+                <ArrowRight className='w-5 h-5 ml-2' />
+              </Button>
+            </Link>
+          </div>
+        </motion.div>
+      </section>
+
+      {/* Footer */}
+      <footer className='relative z-10 border-t border-zinc-800/60 px-6 md:px-12 py-8'>
+        <div className='max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4 text-sm text-zinc-500'>
+          <div className='flex items-center gap-2'>
+            <Clock className='w-4 h-4 text-amber-400/60' />
+            <span>
+              ChronoManager &mdash; {new Date().getFullYear()}
+            </span>
+          </div>
+          <div className='flex items-center gap-6'>
+            <Link href='/app' className='hover:text-amber-400 transition-colors'>
+              Open App
+            </Link>
+            <a
+              href='https://github.com/Abdelkaderbzz/taskly/tree/develop'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='hover:text-amber-400 transition-colors'
+            >
+              GitHub
+            </a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return (
+      <Button variant='ghost' size='icon' className='h-9 w-9' disabled>
+        <Sun className='h-4 w-4' />
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      variant='ghost'
+      size='icon'
+      className='h-9 w-9 text-muted-foreground hover:text-foreground'
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      aria-label='Toggle theme'
+    >
+      {theme === 'dark' ? (
+        <Sun className='h-4 w-4' />
+      ) : (
+        <Moon className='h-4 w-4' />
+      )}
+    </Button>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,10 @@ module.exports = {
       },
     },
     extend: {
+      fontFamily: {
+        display: ["var(--font-display)", "ui-serif", "Georgia", "serif"],
+        body: ["var(--font-body)", "ui-sans-serif", "system-ui", "sans-serif"],
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Summary
- Add a marketing landing page at `/` with a live analog clock hero, orbiting task cards, and footer links (app, portfolio, GitHub)
- Move the task manager into `/app` behind a dedicated app shell with refreshed amber branding
- Add theme support (dark mode toggle, custom fonts) plus app settings for global search, data export/import, and productivity stats

## Test plan
- [ ] Visit `/` and confirm the landing page renders with the live clock and CTA to `/app`
- [ ] Open `/app` and verify task management still works (lists, tasks, views)
- [ ] Toggle dark/light mode and confirm theme persists across reloads
- [ ] Use global search to find tasks across lists
- [ ] Export data from settings, then import it back and confirm data integrity
- [ ] Check productivity stats display expected counts/metrics
- [ ] Confirm footer link to https://abdelkader.work opens correctly


