### PR TITLE
feat: add FeedUser feedback widget

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { rootMetadata } from '@/lib/site-config';
 import { Toaster } from '@/components/ui/toaster';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Syne, DM_Sans } from 'next/font/google';
+import Script from 'next/script';
 import '@/app/globals.css';
 
 const syne = Syne({
@@ -39,6 +40,18 @@ export default function RootLayout({
           {children}
           <Toaster />
         </ThemeProvider>
+        <Script id='feeduser-widget' strategy='afterInteractive'>
+          {`
+            window.Fu = window.Fu || {};
+            Fu.access_token = "c73c052759e3602ca716ff469cde44";
+            (function (d) {
+              const s = d.createElement("script");
+              s.async = true;
+              s.src = "https://widget.feeduser.me/widget/v1.js";
+              (d.head || d.body).appendChild(s);
+            })(document);
+          `}
+        </Script>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Add the FeedUser feedback widget script to the root layout so it loads on every page after the app becomes interactive

## Test plan
- [ ] Open the app and confirm the FeedUser feedback widget appears
- [ ] Verify the widget works on `/`, `/app`, and `/app/focus`
- [ ] Confirm no console errors related to the widget script


